### PR TITLE
KongArmy: Implement status conditions in CR

### DIFF
--- a/roles/kongarmy/meta/main.yml
+++ b/roles/kongarmy/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: license (GPLv2, CC-BY, etc)
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.8
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -58,3 +58,5 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
+collections:
+- operator_sdk.util

--- a/roles/kongarmy/tasks/kong_res_clean.yml
+++ b/roles/kongarmy/tasks/kong_res_clean.yml
@@ -39,5 +39,16 @@
       state: absent
       definition: "{{ lookup('template', 'manifest.yml.j2') }}"
     register: resource_teardown_results
-  
-  # TODO : gather results and update the CR status field
+
+  - name: "Set operator status condition"
+    vars:
+      condition:
+        - type: "{{ 'ResourceCleanFailed' if resource_teardown_results is failed else 'ResourceClean' }}"
+          status: "True"
+          reason: "{{ 'ResourceCleanFailed' if resource_teardown_results is failed 
+            else 'ResourceCleanSucceeded' }}"
+          message: "{{ 'Requested resource ' + kong_requested_resource.kind + ' cleanup failed. Please see ansible container logs for details.' if resource_teardown_results is failed 
+            else 'Requested resource ' + kong_requested_resource.kind + ' successfully removed.' }}"
+          lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+    set_fact:
+      operator_conditions: "{{ operator_conditions + condition }}"

--- a/roles/kongarmy/tasks/kong_res_gen.yml
+++ b/roles/kongarmy/tasks/kong_res_gen.yml
@@ -16,10 +16,20 @@
 - when:
   - not requested_custom_resource|bool
   - not requested_resource_supported|bool
-  debug:
-    msg: "Requested resource {{ kong_requested_resource.kind }} not a part of default KongArmy. Please specify a definition field."
-  
-  # TODO : update the CR status to notify users about the wrong definition / kind
+  block:
+  - debug:
+      msg: "Requested resource {{ kong_requested_resource.kind }} not a part of default KongArmy. Please specify a definition field."
+
+  - name: "Set operator status condition"
+    vars:
+      condition:
+        - type: "ResourceCheckFailed"
+          status: "True"
+          reason: "ResourceCheckFailed"
+          message: "Requested resource {{ kong_requested_resource.kind }} not a part of default KongArmy. Please specify a definition field."
+          lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+    set_fact:
+      operator_conditions: "{{ operator_conditions + condition }}"
 
 - ignore_errors: true
   block:
@@ -52,9 +62,23 @@
       state: present
       definition: "{{ lookup('template', 'manifest.yml.j2') }}"
     register: resource_generation_results
-  
-  # TODO : gather results and update the CR status field
 
+  - debug:
+      var: resource_generation_results
+
+  - name: "Set operator status condition"
+    vars:
+      condition:
+        - type: "{{ 'ResourceGenerateFailed' if resource_generation_results is failed else 'ResourceGenerate' }}"
+          status: "True"
+          reason: "{{ 'ResourceGenFailed' if resource_generation_results is failed 
+            else 'ResourceGenSucceeded' }}"
+          message: "{{ 'Requested resource ' + kong_requested_resource.kind + ' generation failed. Please see ansible container logs for details.' if resource_generation_results is failed 
+            else 'Requested resource ' + kong_requested_resource.kind + ' successfully created.' }}"
+          lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+    set_fact:
+      operator_conditions: "{{ operator_conditions + condition }}"
+  
 - when:
   - (resource_discovery_results.resources | d([]) | length | int) > (kong_requested_resource.count | int)
   ignore_errors: true
@@ -69,5 +93,16 @@
       state: absent
       definition: "{{ lookup('template', 'manifest.yml.j2') }}"
     register: resource_count_reconciliation_results
-  
-  # TODO: update the CR field
+
+  - name: "Set operator status condition"
+    vars:
+      condition:
+        - type: "{{ 'ResourceReconcileFailed' if resource_count_reconciliation_results is failed else 'ResourceReconcile' }}"
+          status: "True"
+          reason: "{{ 'ResourceReconFailed' if resource_count_reconciliation_results is failed 
+            else 'ResourceReconSucceeded' }}"
+          message: "{{ 'Requested resource ' + kong_requested_resource.kind + ' reconcile failed. Please see ansible container logs for details.' if resource_count_reconciliation_results is failed 
+            else 'Requested resource ' + kong_requested_resource.kind + ' successfully reconciled.' }}"
+          lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+    set_fact:
+      operator_conditions: "{{ operator_conditions + condition }}"

--- a/roles/kongarmy/tasks/main.yml
+++ b/roles/kongarmy/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - block:
   - name: Set Reconciled state
-    operator_sdk.util.k8s_status:
+    k8s_status:
       api_version: konveyor.openshift.io/v1alpha1
       kind: KongArmy
       name: "{{ meta.name }}"
@@ -39,3 +39,27 @@
       loop: "{{ requested_resources }}"
       loop_control:
         loop_var: kong_resource
+
+  - set_fact:
+      operator_reconciled: true
+
+  always:
+  - k8s_status:
+      api_version: konveyor.openshift.io/v1alpha1
+      kind: KongArmy
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+      conditions: "{{ operator_conditions }}"
+      status:
+        phase: Reconciled
+    when: operator_reconciled
+
+  - k8s_status:
+      api_version: konveyor.openshift.io/v1alpha1
+      kind: KongArmy
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+      conditions: "{{ operator_conditions }}"
+      status:
+        phase: Failed
+    when: not operator_reconciled


### PR DESCRIPTION
Add manual keeping of CR status, this is due to known OCP 3.x limitations with operators and manageStatus. 
In summary : 

- Implement KongArmy CR status conditions for kong_res_clean and kong_res_gen
- Ensure status phase is also updated as we reconcile operator
- Targets issue #3 

See samples cases below: 

**Failure due to requested bogus kind** 
```
[fbladilo@fdev:~/git-projects/kube-kong-operator/roles/kongarmy/tasks] (update_status *%)$ oc describe kongarmy
Name:         bad-monkey
Namespace:    king-kong
Labels:       <none>
Annotations:  <none>
API Version:  konveyor.openshift.io/v1alpha1
Kind:         KongArmy
Metadata:
  Creation Timestamp:  2020-07-27T03:39:43Z
  Generation:          1
  Resource Version:    3006945
  Self Link:           /apis/konveyor.openshift.io/v1alpha1/namespaces/king-kong/kongarmies/bad-monkey
  UID:                 cf5d2562-cfba-11ea-b2a5-06172c481d9d
Spec:
  requested_resources:
    Count:  8
    Kind:   Blah
Status:
  Conditions:
    Last Transition Time:  2020-07-27T03:59:15Z
    Message:               Requested resource blah not a part of default KongArmy. Please specify a definition field.
    Reason:                ResourceCheckFailed
    Status:                True
    Type:                  ResourceCheckFailed
    Last Transition Time:  2020-07-27T03:59:15Z
    Message:               Requested resource blah generation failed. Please see ansible container logs for details.
    Reason:                ResourceGenFailed
    Status:                True
    Type:                  ResourceGenerateFailed
  Phase:                   Reconciled
Events:                    <none>
```
**Success case using secret resource**
```
[fbladilo@fdev:~/git-projects/kube-kong-operator] (update_status %=)$ oc describe kongarmy good-monkey
Name:         good-monkey
Namespace:    king-kong
Labels:       <none>
Annotations:  <none>
API Version:  konveyor.openshift.io/v1alpha1
Kind:         KongArmy
Metadata:
  Creation Timestamp:  2020-07-27T04:16:05Z
  Generation:          1
  Resource Version:    3010175
  Self Link:           /apis/konveyor.openshift.io/v1alpha1/namespaces/king-kong/kongarmies/good-monkey
  UID:                 e409e3fb-cfbf-11ea-b2a5-06172c481d9d
Spec:
  requested_resources:
    Count:  8
    Kind:   Secret
Status:
  Conditions:
    Last Transition Time:  2020-07-27T04:16:14Z
    Message:               Requested resource secret successfully created.
    Reason:                ResourceGenSucceeded
    Status:                True
    Type:                  ResourceGenerate
  Phase:                   Reconciled
Events:                    <none>
```
**Clean up of secret resources**
```
[fbladilo@fdev:~/git-projects/kube-kong-operator] (update_status %=)$ oc describe kongarmy
Name:         good-monkey
Namespace:    king-kong
Labels:       <none>
Annotations:  <none>
API Version:  konveyor.openshift.io/v1alpha1
Kind:         KongArmy
Metadata:
  Creation Timestamp:  2020-07-27T04:16:05Z
  Generation:          2
  Resource Version:    3010561
  Self Link:           /apis/konveyor.openshift.io/v1alpha1/namespaces/king-kong/kongarmies/good-monkey
  UID:                 e409e3fb-cfbf-11ea-b2a5-06172c481d9d
Spec:
  requested_resources:
    Count:   8
    Kind:    Secret
  Teardown:  true
Status:
  Conditions:
    Last Transition Time:  2020-07-27T04:18:12Z
    Message:               Requested resource secret successfully removed.
    Reason:                ResourceCleanSucceeded
    Status:                True
    Type:                  ResourceClean
  Phase:                   Reconciled
Events:                    <none>
```
